### PR TITLE
Adicionando documentação do softphoneWeb

### DIFF
--- a/pages/softphone-web/_meta.es.json
+++ b/pages/softphone-web/_meta.es.json
@@ -1,0 +1,6 @@
+{
+  "index-1": "Descripción general",
+  "requisites": "Requisitos",
+  "integration-flow": "Flujo de integración",
+  "observations-1": "Observaciones"
+}

--- a/pages/softphone-web/_meta.pt-BR.json
+++ b/pages/softphone-web/_meta.pt-BR.json
@@ -1,0 +1,6 @@
+{
+  "index-1": "Visão Geral",
+  "requisites": "Requisitos",
+  "integration-flow": "Fluxo de Integração",
+  "observations-1": "Observações"
+}

--- a/pages/softphone-web/_meta.us.json
+++ b/pages/softphone-web/_meta.us.json
@@ -1,0 +1,6 @@
+{
+  "index-1": "Overview",
+  "requisites": "Requirements",
+  "integration-flow": "Integration Flow",
+  "observations-1": "Observations"
+}

--- a/pages/softphone-web/index-1.es.mdx
+++ b/pages/softphone-web/index-1.es.mdx
@@ -1,0 +1,4 @@
+# Visión general
+
+La integración web de Softphone le permite incorporar la funcionalidad del teléfono directamente en cualquier aplicación web a través de iframe.De esta manera, CRMS puede ofrecer llamadas de llamadas telefónicas de forma nativa sin la necesidad de una instalación o apertura por separado del softphone OLOS.
+Este enfoque proporciona una experiencia de usuario más fluida, reduce la complejidad técnica y los procesos de servicio.

--- a/pages/softphone-web/index-1.pt-BR.mdx
+++ b/pages/softphone-web/index-1.pt-BR.mdx
@@ -1,0 +1,4 @@
+# Visão Geral
+
+A integração do Softphone Web permite incorporar as funcionalidades de telefonia diretamente em qualquer aplicação web via iFrame. Dessa forma, os CRMs podem oferecer recursos de chamadas telefônicas de maneira nativa, sem a necessidade de instalação ou abertura separada do softphone da Olos.
+Essa abordagem proporciona uma experiência de usuário mais fluida, reduz a complexidade técnica e agiliza os processos de atendimento.

--- a/pages/softphone-web/index-1.us.mdx
+++ b/pages/softphone-web/index-1.us.mdx
@@ -1,0 +1,4 @@
+# Overall Vision
+
+Web softphone integration allows you to incorporate telephone functionality directly into any web application via Iframe.This way, CRMs can offer calls from telephone calls natively without the need for separate installation or opening of the OLOS softphone.
+This approach provides a more fluid user experience, reduces technical complexity and streamlines service processes.

--- a/pages/softphone-web/integration-flow.es.mdx
+++ b/pages/softphone-web/integration-flow.es.mdx
@@ -1,0 +1,10 @@
+# Flujo de integración
+
+Dado que el integrador ya ha realizado la integración con el SDK de Olos Agent, el proceso de activación de SoftphoneWeb se puede iniciar con los siguientes pasos:
+
+1. **Código de acceso**
+2. **Obtención de la URL base de SoftphoneWeb**
+3. **Construyendo la URL final del iframe**
+4. **Inclusión de iframe en la aplicación**
+5. **Escuchando eventos y mensajes.**
+6. **Envío de comandos a SoftphoneWeb (postMessage)**

--- a/pages/softphone-web/integration-flow.pt-BR.mdx
+++ b/pages/softphone-web/integration-flow.pt-BR.mdx
@@ -1,0 +1,10 @@
+# Fluxo de Integração
+
+Tendo em vista que o integrador já tenha realizado a integração com o Olos Agent SDK, o processo de ativação do SoftphoneWeb pode ser iniciado com os seguintes passos:
+
+1. **Passcode**
+2. **Obtenção da URL base do SoftphoneWeb**
+3. **Construção da URL final do iframe**
+4. **Inclusão do iframe na aplicação**
+5. **Ouvindo eventos e mensagens.**
+6. **Envio de Comandos para o SoftphoneWeb (postMessage)**

--- a/pages/softphone-web/integration-flow.us.mdx
+++ b/pages/softphone-web/integration-flow.us.mdx
@@ -1,0 +1,10 @@
+# Integration Flow
+
+Given that the integrator has already performed the integration with the Olos Agent SDK, the SoftphoneWeb activation process can be started with the following steps:
+
+1. **Passcode**
+2. **Obtaining the SoftphoneWeb base URL**
+3. **Building the iframe's final URL**
+4. **Including the iframe in the application**
+5. **Listening to events and messages.**
+6. **Sending Commands to the SoftphoneWeb (postMessage)**

--- a/pages/softphone-web/integration-flow/_meta.es.json
+++ b/pages/softphone-web/integration-flow/_meta.es.json
@@ -1,0 +1,8 @@
+{
+  "passcode": "Passcode",
+  "base-url": "Obtener URL",
+  "iframe-url": "Parse URL",
+  "add-iframe": "Agregar iFrame",
+  "event-listener": "Escuchando eventos",
+  "post-messages": "Post Messages Comandos"
+}

--- a/pages/softphone-web/integration-flow/_meta.pt-BR.json
+++ b/pages/softphone-web/integration-flow/_meta.pt-BR.json
@@ -1,0 +1,8 @@
+{
+  "passcode": "Passcode",
+  "base-url": "Obtendo URL",
+  "iframe-url": "Montando URL",
+  "add-iframe": "Adicionando iFrame",
+  "event-listener": "Ouvindo eventos",
+  "post-messages": "Comandos Post Messages"
+}

--- a/pages/softphone-web/integration-flow/_meta.us.json
+++ b/pages/softphone-web/integration-flow/_meta.us.json
@@ -1,0 +1,8 @@
+{
+  "passcode": "Passcode",
+  "base-url": "Get URL",
+  "iframe-url": "Parse URL",
+  "add-iframe": "Adding iFrame",
+  "event-listener": "Listenning to events",
+  "post-messages": "Post Messages Commands"
+}

--- a/pages/softphone-web/integration-flow/add-iframe.es.mdx
+++ b/pages/softphone-web/integration-flow/add-iframe.es.mdx
@@ -1,0 +1,9 @@
+# 4. Incluir el iframe en la aplicación
+
+Insertar el iframe con la URL construida en el HTML de la aplicación. Asegúrese de configurar correctamente los permisos de seguridad para permitir el uso del micrófono:
+
+Ejemplo:
+
+```html
+<iframe id="SoftphoneWeb" src="https://[domain]/softphonewebrtc/?remote_address=atd-ecs01.olos.com.br&passcode=1184&agent_id=1208" allow="microphone" sandbox="allow-same-origin allow-scripts allow-forms"></iframe>
+```

--- a/pages/softphone-web/integration-flow/add-iframe.pt-BR.mdx
+++ b/pages/softphone-web/integration-flow/add-iframe.pt-BR.mdx
@@ -1,0 +1,9 @@
+# 4.	Inclusão do iframe na aplicação
+
+Insira o iframe com a URL construída no HTML da aplicação. Certifique-se de configurar corretamente as permissões de segurança para permitir o uso do microfone:
+
+Exemplo:
+
+```html
+<iframe id="SoftphoneWeb" src="https://[domain]/softphonewebrtc/?remote_address=atd-ecs01.olos.com.br&passcode=1184&agent_id=1208" allow="microphone" sandbox="allow-same-origin allow-scripts allow-forms"></iframe>
+```

--- a/pages/softphone-web/integration-flow/add-iframe.us.mdx
+++ b/pages/softphone-web/integration-flow/add-iframe.us.mdx
@@ -1,0 +1,9 @@
+# 4. Including the iframe in the application
+
+Insert the iframe with the URL built into the application's HTML. Make sure to correctly configure the security permissions to allow the use of the microphone:
+
+Example:
+
+```html
+<iframe id="SoftphoneWeb" src="https://[domain]/softphonewebrtc/?remote_address=atd-ecs01.olos.com.br&passcode=1184&agent_id=1208" allow="microphone" sandbox="allow-same-origin allow-scripts allow-forms"></iframe>
+```

--- a/pages/softphone-web/integration-flow/base-url.es.mdx
+++ b/pages/softphone-web/integration-flow/base-url.es.mdx
@@ -1,0 +1,13 @@
+# 2. Obtención de la URL base de SoftphoneWeb
+
+A continuación, deberá realizar una llamada a la siguiente API para recuperar la URL base del softphone:
+
+```
+GET https://[domain]/WebApiSoftphone/Softphone/GetPbxToLogin
+```
+
+Respuesta de ejemplo:
+
+```
+"https://[domain]/softphonewebrtc/?remote_address=atd-ecs01.olos.com.br&"
+``` 

--- a/pages/softphone-web/integration-flow/base-url.pt-BR.mdx
+++ b/pages/softphone-web/integration-flow/base-url.pt-BR.mdx
@@ -1,0 +1,13 @@
+# 2.	Obtenção da URL base do SoftphoneWeb
+
+Em seguida, será necessário realizar uma chamada à seguinte API para recuperar a URL base do softphone:
+
+```
+GET https://[domain]/WebApiSoftphone/Softphone/GetPbxToLogin
+```
+
+Exemplo de resposta:
+
+```
+"https://[domain]/softphonewebrtc/?remote_address=atd-ecs01.olos.com.br&"
+``` 

--- a/pages/softphone-web/integration-flow/base-url.us.mdx
+++ b/pages/softphone-web/integration-flow/base-url.us.mdx
@@ -1,0 +1,13 @@
+# 2. Obtaining the SoftphoneWeb base URL
+
+Next, you will need to make a call to the following API to retrieve the softphone base URL:
+
+```
+GET https://[domain]/WebApiSoftphone/Softphone/GetPbxToLogin
+```
+
+Example response:
+
+```
+"https://[domain]/softphonewebrtc/?remote_address=atd-ecs01.olos.com.br&"
+``` 

--- a/pages/softphone-web/integration-flow/event-listener.es.mdx
+++ b/pages/softphone-web/integration-flow/event-listener.es.mdx
@@ -1,0 +1,39 @@
+# 5.	Escuchando eventos y mensajes.
+
+Después de que se incluye iframe en el documento, el siguiente paso es agregar un oyente de eventos al objeto de la ventana. Esto permitirá que su aplicación comience a escuchar los mensajes enviados por SoftphoneWeb iframe, lo que permite el control de eventos importantes relacionados con la conexión de Softphone.
+
+El oyente debe estar configurado para capturar tres mensajes de mensajes:
+
+- **disconnect** – Este mensaje se envía cuando ocurre una desconexión de un softphone, por ejemplo, si el agente se desconecta o se pierde la conexión PBX.
+- **connect** – Indica que la conexión entre el navegador y el softphone se realizó con éxito.
+- **getUserMediaFail** – Se indica que hubo una falla al tratar de obtener acceso al micrófono, generalmente por bloqueo del navegador o ausencia de permiso otorgado por el usuario.
+
+Los mensajes siempre vienen en el siguiente formato: “softPhoneResponse|*tipo_mesage*”
+
+### Ejemplo:
+
+-	softPhoneResponse|disconnect
+-	softPhoneResponse|connect
+-	softPhoneResponse|getUserMediaFail
+
+A continuación se muestra un ejemplo de cómo agregar y tratar a este oyente en JavaScript
+
+```js
+window.addEventListener("message", function (event) {
+  if (typeof event.data === "string" && event.data.includes("softPhoneResponse|")) {
+    const [, messageType] = event.data.split("|");
+
+    switch (messageType) {
+      case "disconnect":
+        console.warn("Softphone desconectado.");
+        break;
+      case "connect":
+        console.log("Softphone conectado con éxito.");
+        break;
+      case "getUserMediaFail":
+        console.error("Falla al acceder al micrófono.");
+        break;
+    }
+  }
+});
+```

--- a/pages/softphone-web/integration-flow/event-listener.pt-BR.mdx
+++ b/pages/softphone-web/integration-flow/event-listener.pt-BR.mdx
@@ -1,0 +1,39 @@
+# 5.	Ouvindo eventos e mensagens.
+
+Após a inclusão do iframe no documento, o próximo passo é adicionar um Event Listener no objeto window. Isso permitirá que sua aplicação comece a escutar as mensagens enviadas pelo iframe do SoftphoneWeb, possibilitando o controle de eventos importantes relacionados à conexão do softphone.
+
+O listener deve ser configurado para capturar três tipos de mensagens:
+
+- **disconnect** – Esta mensagem é enviada quando ocorre uma desconexão do softphone, por exemplo, se o agente se desconectar ou a conexão com o PBX for perdida.
+- **connect** – Indica que a conexão entre o navegador e o softphone foi realizada com sucesso.
+- **getUserMediaFail** – Sinaliza que houve uma falha ao tentar obter acesso ao microfone, normalmente por bloqueio do navegador ou ausência de permissão concedida pelo usuário.
+
+As mensagens chegam sempre no seguinte formato: "softPhoneResponse|*tipo_da_mensagem*"
+
+### Exemplo:
+
+-	softPhoneResponse|disconnect
+-	softPhoneResponse|connect
+-	softPhoneResponse|getUserMediaFail
+
+Abaixo, um exemplo de como adicionar e tratar esse listener em JavaScript
+
+```js
+window.addEventListener("message", function (event) {
+  if (typeof event.data === "string" && event.data.includes("softPhoneResponse|")) {
+    const [, messageType] = event.data.split("|");
+
+    switch (messageType) {
+      case "disconnect":
+        console.warn("Softphone desconectado.");
+        break;
+      case "connect":
+        console.log("Softphone conectado com sucesso.");
+        break;
+      case "getUserMediaFail":
+        console.error("Falha ao acessar o microfone.");
+        break;
+    }
+  }
+});
+```

--- a/pages/softphone-web/integration-flow/event-listener.us.mdx
+++ b/pages/softphone-web/integration-flow/event-listener.us.mdx
@@ -1,0 +1,39 @@
+# 5.	Listening to events and messages.
+
+After IFRAME is included in the document, the next step is to add an event listener to the Window object.This will allow your application to start listening to the messages sent by the softphoneweb Iframe, enabling the control of important events related to the softphone connection.
+
+The listener must be configured to capture three messages of messages:
+
+- **disconnect** – This message is sent when a softphone disconnection occurs, for example, if the agent disconnects or the PBX connection is lost.
+- **connect** – It indicates that the connection between the browser and the softphone was successfully made.
+- **getUserMediaFail** – It signals that there was a failure when trying to gain access to the microphone, usually by lockout of the browser or absence of permission granted by the user.
+
+The messages always come in the following format: “softPhoneResponse|*message_type*”
+
+### Example:
+
+-	softPhoneResponse|disconnect
+-	softPhoneResponse|connect
+-	softPhoneResponse|getUserMediaFail
+
+Below is an example of how to add and treat this listener in JavaScript
+
+```js
+window.addEventListener("message", function (event) {
+  if (typeof event.data === "string" && event.data.includes("softPhoneResponse|")) {
+    const [, messageType] = event.data.split("|");
+
+    switch (messageType) {
+      case "disconnect":
+        console.warn("Softphone disconnected.");
+        break;
+      case "connect":
+        console.log("Successfully connected softphone.");
+        break;
+      case "getUserMediaFail":
+        console.error("Failure when accessing the microphone.");
+        break;
+    }
+  }
+});
+```

--- a/pages/softphone-web/integration-flow/iframe-url.es.mdx
+++ b/pages/softphone-web/integration-flow/iframe-url.es.mdx
@@ -1,0 +1,12 @@
+# 3. Construyendo la URL final del iframe
+
+Con la URL devuelta, ensamble la URL final agregando los parámetros requeridos a través de la cadena de consulta:
+
+- passcode → el código de 4 dígitos recibido previamente
+- agent_id → el ID del agente que inició sesión
+
+Ejemplo de URL final
+
+```
+https://[domain]/softphonewebrtc/?remote_address=atd-ecs01.olos.com.br&passcode=1184&agent_id=1208
+```

--- a/pages/softphone-web/integration-flow/iframe-url.pt-BR.mdx
+++ b/pages/softphone-web/integration-flow/iframe-url.pt-BR.mdx
@@ -1,0 +1,12 @@
+# 3.	Construção da URL final do iframe
+
+Com a URL retornada, monte a URL final adicionando os parâmetros obrigatórios via query string:
+
+- passcode → o código de 4 dígitos recebido anteriormente
+- agent_id → o ID do agente logado
+
+Exemplo de URL final
+
+```
+https://[domain]/softphonewebrtc/?remote_address=atd-ecs01.olos.com.br&passcode=1184&agent_id=1208
+```

--- a/pages/softphone-web/integration-flow/iframe-url.us.mdx
+++ b/pages/softphone-web/integration-flow/iframe-url.us.mdx
@@ -1,0 +1,12 @@
+# 3. Building the iframe's final URL
+
+With the returned URL, build the final URL by adding the required parameters via query string:
+
+- passcode → the 4-digit code received previously
+- agent_id → the ID of the logged-in agent
+
+Example of final URL
+
+```
+https://[domain]/softphonewebrtc/?remote_address=atd-ecs01.olos.com.br&passcode=1184&agent_id=1208
+```

--- a/pages/softphone-web/integration-flow/passcode.es.mdx
+++ b/pages/softphone-web/integration-flow/passcode.es.mdx
@@ -1,0 +1,6 @@
+# 1. Recibir el código de acceso
+
+Después de la autenticación en Olos, el agente que inició sesión recibirá el evento que contiene el código de acceso (un código numérico de 4 dígitos) necesario para la autenticación en el CCM.
+
+⚠️ **Atención**: El agente debe estar vinculado a al menos una campaña de voz. De lo contrario, el sistema enviará el evento LoginCCMFail en lugar del código de acceso.
+Guarde el número de contraseña recibido para usarlo más adelante.

--- a/pages/softphone-web/integration-flow/passcode.pt-BR.mdx
+++ b/pages/softphone-web/integration-flow/passcode.pt-BR.mdx
@@ -1,0 +1,6 @@
+# 1.	Recebimento do Passcode
+
+Após a autenticação no Olos, o agente logado receberá o evento contendo o passcode — um código de 4 dígitos numéricos — necessário para autenticação no CCM.
+
+⚠️ **Atenção**: O agente deve estar vinculado a pelo menos uma campanha de voz. Caso contrário, o sistema enviará o evento LoginCCMFail ao invés do passcode.
+Armazene o número recebido do passcode para uso posterior.

--- a/pages/softphone-web/integration-flow/passcode.us.mdx
+++ b/pages/softphone-web/integration-flow/passcode.us.mdx
@@ -1,0 +1,6 @@
+# 1. Receiving the Passcode
+
+After authenticating in Olos, the logged-in agent will receive the event containing the passcode — a 4-digit numeric code — required for authentication in the CCM.
+
+⚠️ **Attention**: The agent must be linked to at least one voice campaign. Otherwise, the system will send the LoginCCMFail event instead of the passcode.
+Store the received passcode number for later use.

--- a/pages/softphone-web/integration-flow/post-messages.es.mdx
+++ b/pages/softphone-web/integration-flow/post-messages.es.mdx
@@ -1,0 +1,75 @@
+# 6.	Presentación de comandos a SoftphoneWeb (postMessage)
+
+Una vez recibida la señal de conexión ("connect"), el agente está listo para realizar llamadas. A partir de ese momento, tu aplicación podrá comunicarse con el iframe de SoftphoneWeb enviando comandos mediante postMessage.
+
+### **Ejemplo de envío de mensaje**
+
+```js
+const iframeElement = document.getElementsByTagName("iframe")[0];
+iframeElement.contentWindow.postMessage(mensagem, iframeElement.src.split("?")[0]);
+```
+
+> ⚠️ Asegúrate de capturar correctamente el elemento 'iframe' y usar el dominio base como targetOrigin por seguridad.
+
+### **Comandos disponibles**
+
+A continuación, los comandos que pueden enviarse al iframe y su descripción:
+
+1. **setSpeakVolume**: Define el volumen del altavoz  
+
+Ejemplo:
+```js
+`setSpeakVolume|0.8` // (define el volumen del altavoz al 80%)
+```
+
+2. **setMicVolume**: Define el volumen del micrófono  
+
+Ejemplo:
+```js
+`setMicVolume|0.6` // (define el volumen del micrófono al 60%)
+```
+
+3. **toggleMute**: Alterna entre silenciar y activar el altavoz  
+
+Ejemplo:
+```js
+`toggleMute`
+```
+
+4. **muteMic**: Silencia el micrófono del agente  
+
+Ejemplo:
+```js
+`muteMic`
+```
+
+5. **unmuteMic**: Activa el micrófono del agente  
+
+Ejemplo:
+```js
+`unmuteMic`
+```
+
+6. **sendDtmf**: Envía tonos DTMF (teclas del teclado numérico durante la llamada)  
+
+Ejemplo:
+```js
+`sendDtmf|5`
+```
+
+A continuación, una tabla con la correspondencia de cada comando DTMF:
+
+| Valor | Carácter |
+|-------|----------|
+| 1     |          |
+| 2     | ABC      |
+| 3     | DEF      |
+| 4     | GHI      |
+| 5     | JKL      |
+| 6     | MNO      |
+| 7     | PQRS     |
+| 8     | TUV      |
+| 9     | WXYZ     |
+| *     |          |
+| 0     | +        |
+| #     |          |

--- a/pages/softphone-web/integration-flow/post-messages.pt-BR.mdx
+++ b/pages/softphone-web/integration-flow/post-messages.pt-BR.mdx
@@ -1,0 +1,75 @@
+# 6.	Envio de Comandos para o SoftphoneWeb (postMessage)
+
+Uma vez que a mensagem de conexão ("connect") tenha sido recebida, o agente está pronto para realizar chamadas. A partir desse ponto, sua aplicação poderá se comunicar com o iframe do SoftphoneWeb enviando comandos via postMessage.
+
+### **Exemplo de envio de mensagem**
+
+```js
+const iframeElement = document.getElementsByTagName("iframe")[0];
+iframeElement.contentWindow.postMessage(mensagem, iframeElement.src.split("?")[0]);
+```
+
+> ⚠️ Certifique-se de capturar corretamente o elemento 'iframe' e de utilizar o domínio base como targetOrigin para segurança.
+
+### **Comandos disponíveis**
+
+A seguir, os comandos que podem ser enviados para o iframe e sua descrição:
+
+1. **setSpeakVolume**: Define o volume do alto-falante (speaker)
+
+Exemplo:
+```js
+'setSpeakVolume|0.8' // (define o volume do speaker em 80%)
+```
+
+2. **setMicVolume**: Define o volume do microfone.
+
+Exemplo:
+```js
+'setMicVolume|0.6 // (define o volume do microfone em 60%)'
+```
+
+3. **toggleMute**: Alterna entre mutar e desmutar o speaker.
+
+Exemplo:
+```js
+'toggleMute'
+```
+
+4. **muteMic**: Muta o microfone do agente.
+
+Exemplo:
+```js
+'muteMic'
+```
+
+5. **unmuteMic**: Desmuta o microfone do agente.
+
+Exemplo:
+```js
+'unmuteMic'
+```
+
+6. **sendDtmf**: Envia tons DTMF (teclas do teclado numérico durante a chamada).
+
+Exemplo:
+```js
+'sendDtmf|5'
+```
+
+Abaixo uma tabela com o de/para de cada comando Dtmf:
+
+|Valor|Caracter|
+|--|--|
+|1|  |
+|2|ABC|
+|3|DEF|
+|4|GHI|
+|5|JKL|
+|6|MNO|
+|7|PQRS|
+|8|TUV|
+|9|WXYZ|
+|*|  |
+|0|+|	
+|#|  |

--- a/pages/softphone-web/integration-flow/post-messages.us.mdx
+++ b/pages/softphone-web/integration-flow/post-messages.us.mdx
@@ -1,0 +1,75 @@
+# 6.	Submission of commands to softphoneweb (postMessage)
+
+Once the connection message ("connect") has been received, the agent is ready to make calls. From this point on, your application can communicate with the SoftphoneWeb iframe by sending commands via postMessage.
+
+### **Message sending example**
+
+```js
+const iframeElement = document.getElementsByTagName("iframe")[0];
+iframeElement.contentWindow.postMessage(mensagem, iframeElement.src.split("?")[0]);
+```
+
+> ⚠️ Make sure to correctly capture the 'iframe' element and use the base domain as the targetOrigin for security.
+
+### **Available commands**
+
+Below are the commands that can be sent to the iframe and their description:
+
+1. **setSpeakVolume**: Sets the speaker volume  
+
+Example:
+```js
+`setSpeakVolume|0.8` // (sets the speaker volume to 80%)
+```
+
+2. **setMicVolume**: Sets the microphone volume  
+
+Example:
+```js
+`setMicVolume|0.6` // (sets the microphone volume to 60%)
+```
+
+3. **toggleMute**: Toggles between muting and unmuting the speaker  
+
+Example:
+```js
+`toggleMute`
+```
+
+4. **muteMic**: Mutes the agent's microphone  
+
+Example:
+```js
+`muteMic`
+```
+
+5. **unmuteMic**: Unmutes the agent's microphone  
+
+Example:
+```js
+`unmuteMic`
+```
+
+6. **sendDtmf**: Sends DTMF tones (numeric keypad keys during the call)  
+
+Example:
+```js
+`sendDtmf|5`
+```
+
+Below is a table mapping each DTMF command:
+
+| Value | Character |
+|-------|-----------|
+| 1     |           |
+| 2     | ABC       |
+| 3     | DEF       |
+| 4     | GHI       |
+| 5     | JKL       |
+| 6     | MNO       |
+| 7     | PQRS      |
+| 8     | TUV       |
+| 9     | WXYZ      |
+| *     |           |
+| 0     | +         |
+| #     |           |

--- a/pages/softphone-web/observations-1.es.mdx
+++ b/pages/softphone-web/observations-1.es.mdx
@@ -1,0 +1,4 @@
+# Observaciones
+
+- Los comandos enviados a través del postMessage no tienen respuesta. La aplicación debe considerar que al enviar un mensaje, la ejecución se realizará de inmediato.
+- Recomendamos implementar controles visuales que reflejen el estado deseado de la interfaz (por ejemplo: icono de micrófono mutado), ya que SoftphoneWeb no envía confirmación de ejecución.

--- a/pages/softphone-web/observations-1.pt-BR.mdx
+++ b/pages/softphone-web/observations-1.pt-BR.mdx
@@ -1,0 +1,4 @@
+# Observações
+
+- Os comandos enviados via postMessage não possuem resposta. A aplicação deve considerar que, ao enviar uma mensagem, a execução será feita imediatamente.
+- Recomendamos implementar controles visuais que reflitam o estado desejado da interface (por exemplo: ícone de microfone mutado), uma vez que o SoftphoneWeb não envia confirmação de execução.

--- a/pages/softphone-web/observations-1.us.mdx
+++ b/pages/softphone-web/observations-1.us.mdx
@@ -1,0 +1,4 @@
+# Notes
+
+- Commands sent via postMessage do not have a response. The application must consider that, when sending a message, the execution will be done immediately.
+- We recommend implementing visual controls that reflect the desired state of the interface (for example: muted microphone icon), since SoftphoneWeb does not send execution confirmation.

--- a/pages/softphone-web/requisites.es.mdx
+++ b/pages/softphone-web/requisites.es.mdx
@@ -1,0 +1,15 @@
+# Requisitos
+
+Para garantizar el correcto funcionamiento de la integración de **Softphone Web**, se deben cumplir los siguientes requisitos
+
+ - **Entorno HTTPS**
+La aplicación que integrará el Web Softphone deberá ejecutarse en un entorno HTTPS, ya que el acceso al micrófono a través del navegador requiere de una conexión segura.
+
+ - **Integración previa con Olos Agent SDK**
+La aplicación ya debe estar integrada con el **Olos Agent SDK**, que es responsable de administrar eventos y la autenticación de telefonía.
+
+ - **Softphone.js instalado y configurado**
+El integrador debe incluir y configurar correctamente la aplicación **softphone.js** en el entorno.
+
+ - **WebApiSoftphone instalado y configurado**
+También es necesario que el servicio **WebApiSoftphone** esté instalado y configurado.

--- a/pages/softphone-web/requisites.pt-BR.mdx
+++ b/pages/softphone-web/requisites.pt-BR.mdx
@@ -1,0 +1,17 @@
+# Requisitos
+
+Para garantir o funcionamento correto da integração do **Softphone Web**, é necessário atender aos seguintes requisitos
+
+ - **Ambiente HTTPS**
+A aplicação que integrará o Softphone Web deve obrigatoriamente rodar em ambiente HTTPS, pois o acesso ao microfone pelo navegador exige conexão segura.
+
+ - **Integração prévia com Olos Agent SDK**
+A aplicação deve já estar integrada com o **Olos Agent SDK**, que é responsável pelo gerenciamento dos eventos e autenticação de telefonia.
+
+ - **Softphone.js instalado e configurado**
+O integrador deve incluir e configurar corretamente a aplicação **softphone.js** no ambiente.
+
+ - **WebApiSoftphone instalado e configurado**
+É necessário também que o serviço **WebApiSoftphone** esteja instalado e configurado.
+
+

--- a/pages/softphone-web/requisites.us.mdx
+++ b/pages/softphone-web/requisites.us.mdx
@@ -1,0 +1,15 @@
+# Requirements
+
+To ensure that the **Softphone Web** integration works correctly, the following requirements must be met
+
+- **HTTPS environment**
+The application that will integrate the Softphone Web must run in an HTTPS environment, since access to the microphone via the browser requires a secure connection.
+
+- **Prior integration with Olos Agent SDK**
+The application must already be integrated with the **Olos Agent SDK**, which is responsible for managing events and telephony authentication.
+
+- **Softphone.js installed and configured**
+The integrator must include and correctly configure the **softphone.js** application in the environment.
+
+- **WebApiSoftphone installed and configured**
+It is also necessary that the **WebApiSoftphone** service is installed and configured.


### PR DESCRIPTION
A integração do Softphone Web permite incorporar as funcionalidades de telefonia diretamente em qualquer aplicação web via iFrame. Dessa forma, os CRMs podem oferecer recursos de chamadas telefônicas de maneira nativa, sem a necessidade de instalação ou abertura separada do softphone da Olos.

Essa abordagem proporciona uma experiência de usuário mais fluida, reduz a complexidade técnica e agiliza os processos de atendimento.